### PR TITLE
SAAS-567 Add Switch component

### DIFF
--- a/src/components/Switch/Switch.styles.ts
+++ b/src/components/Switch/Switch.styles.ts
@@ -1,0 +1,37 @@
+import { css } from 'emotion';
+import { GrafanaTheme } from '@grafana/data';
+
+export const getStyles = ({ spacing, palette, typography, colors }: GrafanaTheme) => ({
+  field: css`
+    &:not(:last-child) {
+      margin-bottom: ${spacing.formInputMargin};
+    }
+  `,
+  label: css`
+    display: block;
+    text-align: left;
+    font-size: ${typography.size.md};
+    font-weight: ${typography.weight.semibold};
+    line-height: 1.25;
+    margin: ${spacing.formLabelMargin};
+    padding: ${spacing.formLabelPadding};
+    color: ${colors.formLabel};
+  `,
+  labelWrapper: css`
+    align-items: center;
+    display: flex;
+    flex-direction: row;
+    div[class$='-Icon'] {
+      display: flex;
+      margin-left: ${spacing.xs};
+    }
+  `,
+  errorMessage: css`
+    color: ${palette.red};
+    font-size: ${typography.size.sm};
+    height: ${typography.size.sm};
+    line-height: ${typography.lineHeight.sm};
+    margin-top: ${spacing.sm};
+    margin-bottom: ${spacing.xs};
+  `,
+});

--- a/src/components/Switch/Switch.test.tsx
+++ b/src/components/Switch/Switch.test.tsx
@@ -1,0 +1,75 @@
+import React from 'react';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { FormWrapper } from '../../shared';
+import { SwitchField } from './Switch';
+
+describe('SwitchField::', () => {
+  it('should render an input element of type checkbox', () => {
+    const { container } = render(
+      <FormWrapper>
+        <SwitchField name="test" />
+      </FormWrapper>,
+    );
+
+    expect(container.querySelector('input')).toHaveProperty('type', 'checkbox');
+  });
+
+  it('should call passed validators', () => {
+    const validatorOne = jest.fn();
+    const validatorTwo = jest.fn();
+
+    render(
+      <FormWrapper>
+        <SwitchField name="test" validators={[validatorOne, validatorTwo]} />
+      </FormWrapper>,
+    );
+
+    expect(validatorOne).toBeCalledTimes(1);
+    expect(validatorTwo).toBeCalledTimes(1);
+  });
+
+  it('should show no labels if one is not specified', () => {
+    render(
+      <FormWrapper>
+        <SwitchField name="test" />
+      </FormWrapper>,
+    );
+
+    expect(screen.queryByTestId('test-field-label')).not.toBeInTheDocument();
+  });
+
+  it('should show a label if one is specified', async () => {
+    render(
+      <FormWrapper>
+        <SwitchField label="test label" name="test" />
+      </FormWrapper>,
+    );
+
+    expect((screen.getByTestId('test-field-label').textContent)).toBe('test label');
+  });
+
+  it('should change the state value when clicked', async () => {
+    render(
+      <FormWrapper>
+        <SwitchField name="test" />
+      </FormWrapper>,
+    );
+    const switchField = screen.getByTestId('test-switch');
+
+    expect(switchField).toHaveProperty('checked', false);
+
+    fireEvent.change(switchField, { target: { checked: true } });
+
+    expect(switchField).toHaveProperty('checked', true);
+  });
+
+  it('should disable switch when `disabled` is passed via props', () => {
+    const { container } = render(
+      <FormWrapper>
+        <SwitchField name="test" disabled />
+      </FormWrapper>,
+    );
+
+    expect(container.querySelector('input')).toHaveProperty('disabled', true);
+  });
+});

--- a/src/components/Switch/Switch.tsx
+++ b/src/components/Switch/Switch.tsx
@@ -1,0 +1,50 @@
+import React, { FC, useMemo } from 'react';
+import { Field } from 'react-final-form';
+import { cx } from 'emotion';
+import { Icon, Tooltip, Switch, useStyles } from '@grafana/ui';
+import { compose } from '../../shared/validators';
+import { SwitchFieldProps, SwitchFieldRenderProps } from './Switch.types';
+import { getStyles } from './Switch.styles';
+
+export const SwitchField: FC<SwitchFieldProps> = ({
+  disabled,
+  fieldClassName,
+  inputProps,
+  label,
+  name,
+  validators,
+  tooltip,
+  tooltipIcon = 'info-circle',
+  ...fieldConfig
+}) => {
+  const styles = useStyles(getStyles);
+  const inputId = `input-${name}-id`;
+  const validate = useMemo(() => (Array.isArray(validators) ? compose(...validators) : undefined), [
+    validators,
+  ]);
+
+  return (
+    <Field<boolean> {...fieldConfig} type="checkbox" name={name} validate={validate}>
+      {({ input, meta }: SwitchFieldRenderProps) => (
+        <div className={cx(styles.field, fieldClassName)} data-qa={`${name}-field-container`}>
+          {label && (
+            <div className={styles.labelWrapper}>
+              <label className={styles.label} htmlFor={inputId} data-qa={`${name}-field-label`}>
+                {label}
+              </label>
+              {tooltip && (
+                <Tooltip content={<span>{tooltip}</span>} data-qa={`${name}-field-tooltip`}>
+                  <Icon name={tooltipIcon} />
+                </Tooltip>
+              )}
+            </div>
+          )}
+          <Switch css={{}} {...input} value={input.checked} disabled={disabled} data-qa={`${name}-switch`} />
+          <div data-qa={`${name}-field-error-message`} className={styles.errorMessage}>
+            {meta.touched && meta.error}
+          </div>
+        </div>
+      )}
+    </Field>
+  );
+};

--- a/src/components/Switch/Switch.types.ts
+++ b/src/components/Switch/Switch.types.ts
@@ -1,0 +1,21 @@
+import { ReactNode } from 'react';
+import { FieldInputProps, FieldMetaState, UseFieldConfig } from 'react-final-form';
+import { IconName } from '@grafana/ui';
+import { FieldInputAttrs } from '../../shared/types';
+import { Validator } from '../../shared/validators';
+
+export interface SwitchFieldRenderProps {
+  input: FieldInputProps<string, HTMLInputElement>;
+  meta: FieldMetaState<string>;
+}
+
+export interface SwitchFieldProps extends UseFieldConfig<boolean> {
+  disabled?: boolean;
+  fieldClassName?: string;
+  inputProps?: FieldInputAttrs;
+  label?: string | ReactNode;
+  name: string;
+  validators?: Validator[];
+  tooltip?: string;
+  tooltipIcon?: IconName;
+}

--- a/src/setupTests.ts
+++ b/src/setupTests.ts
@@ -6,9 +6,11 @@ import '@testing-library/jest-dom/extend-expect';
 import 'jest-canvas-mock';
 import 'jest-enzyme';
 import { configure } from 'enzyme';
+import { configure as configureTestingLibrary } from '@testing-library/react';
 import * as Adapter from 'enzyme-adapter-react-16';
 
 const adapter = Adapter as any;
 
 // eslint-disable-next-line new-cap
 configure({ adapter: new adapter.default() });
+configureTestingLibrary({ testIdAttribute: 'data-qa' });


### PR DESCRIPTION
- Adds `Switch` component to core
- Configures `data-qa` as test id for react testing library and uses it on `Switch` component tests

Fixes https://jira.percona.com/browse/SAAS-567

This PR solves the change requested in https://github.com/percona-platform/grafana/pull/172 to add the `Switch` component created there to core