### PR TITLE
PMM-7809 Fix button type

### DIFF
--- a/src/components/LoaderButton/LoaderButton.tsx
+++ b/src/components/LoaderButton/LoaderButton.tsx
@@ -1,6 +1,18 @@
-import React, { FC } from 'react';
-import { Button, Spinner } from '@grafana/ui';
-import { ButtonProps } from '@grafana/ui/components/Button';
+import React, { ButtonHTMLAttributes, FC } from 'react';
+import { Button, ButtonVariant, IconName, Spinner } from '@grafana/ui';
+
+type ComponentSize = 'xs' | 'sm' | 'md' | 'lg';
+
+type CommonProps = {
+  size?: ComponentSize;
+  variant?: ButtonVariant;
+  icon?: IconName;
+  className?: string;
+  children?: React.ReactNode;
+  fullWidth?: boolean;
+};
+
+type ButtonProps = CommonProps & ButtonHTMLAttributes<HTMLButtonElement>;
 
 interface LoaderButtonProps extends ButtonProps {
   loading?: boolean;


### PR DESCRIPTION
Relative import does not work because in grafana the folder structure of grafana/ui package is different and since grafana removed the export for `ButtonProps` defining the types in our code seems to be the solution for now to not mess with how grafana is building grafana/ui package on grafana project.