### PR TITLE
PMM-9081-create-copyToClipboard-component: add component

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@percona/platform-core",
-  "version": "0.10.2",
+  "version": "0.10.3-0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@percona/platform-core",
-  "version": "0.10.2",
+  "version": "0.10.3-0",
   "description": "Platform UI core components",
   "private": false,
   "keywords": [

--- a/src/components/CopyToClipboard/CopyToClipboard.stories.tsx
+++ b/src/components/CopyToClipboard/CopyToClipboard.stories.tsx
@@ -1,0 +1,37 @@
+import React, { useRef } from 'react';
+import { ComponentStory, ComponentMeta } from '@storybook/react';
+import { CopyToClipboard } from './CopyToClipboard';
+import { Button } from "@grafana/ui";
+
+export default {
+  title: 'Buttons/CopyToClipboard',
+  component: CopyToClipboard,
+} as ComponentMeta<typeof CopyToClipboard>;
+
+const Template: ComponentStory<typeof CopyToClipboard> = (args) => {
+  const outputRef = useRef(null);
+
+  return (
+    <div>
+        <div ref={outputRef}>
+          <p>
+            <span>Test some text to Copy (span1). </span>
+            <span>Test some text to Copy (span2).</span>
+            <Button>Test some text to Copy (button). </Button>
+            Test some text to Copy (p).
+          </p>
+          <p>
+            Test some text to Copy in "p" tag with using "br" tag<br/>Next string after br tag
+          </p>
+          <p>
+            {"Test some text to Copy in p tag with using u000A unicode\u000ANext string after u000A"}
+          </p>
+          <div>Test some text to Copy (div)</div>
+        </div>
+       <CopyToClipboard {...args} textContainer={outputRef}/>
+    </div>
+  )
+}
+
+export const Basic = Template.bind({});
+Basic.args = {};

--- a/src/components/CopyToClipboard/CopyToClipboard.stories.tsx
+++ b/src/components/CopyToClipboard/CopyToClipboard.stories.tsx
@@ -1,7 +1,7 @@
 import React, { useRef } from 'react';
 import { ComponentStory, ComponentMeta } from '@storybook/react';
+import { Button } from '@grafana/ui';
 import { CopyToClipboard } from './CopyToClipboard';
-import { Button } from "@grafana/ui";
 
 export default {
   title: 'Buttons/CopyToClipboard',
@@ -13,25 +13,25 @@ const Template: ComponentStory<typeof CopyToClipboard> = (args) => {
 
   return (
     <div>
-        <div ref={outputRef}>
+      <div ref={outputRef}>
+        <p>
+          <span>Test some text to Copy (span1). </span>
+          <span>Test some text to Copy (span2).</span>
+          <Button>Test some text to Copy (button). </Button>
+          Test some text to Copy (p).
+        </p>
+        <p>
+          Test some text to Copy in p tag with using br tag<br/>Next string after br tag
+        </p>
           <p>
-            <span>Test some text to Copy (span1). </span>
-            <span>Test some text to Copy (span2).</span>
-            <Button>Test some text to Copy (button). </Button>
-            Test some text to Copy (p).
-          </p>
-          <p>
-            Test some text to Copy in "p" tag with using "br" tag<br/>Next string after br tag
-          </p>
-          <p>
-            {"Test some text to Copy in p tag with using u000A unicode\u000ANext string after u000A"}
+            {'Test some text to Copy in p tag with using u000A unicode\u000ANext string after u000A'}
           </p>
           <div>Test some text to Copy (div)</div>
         </div>
        <CopyToClipboard {...args} textContainer={outputRef}/>
     </div>
-  )
-}
+  );
+};
 
 export const Basic = Template.bind({});
 Basic.args = {};

--- a/src/components/CopyToClipboard/CopyToClipboard.styles.ts
+++ b/src/components/CopyToClipboard/CopyToClipboard.styles.ts
@@ -2,11 +2,11 @@ import { GrafanaTheme } from '@grafana/data';
 import { css } from 'emotion';
 
 export const getStyles = (theme: GrafanaTheme) => {
-  const { spacing, colors, border } = theme;
+  const { spacing, colors, border, zIndex } = theme;
 
   return {
     tooltip: css`
-      z-index: 1;
+      z-index: ${zIndex.tooltip};
     `,
     tooltipText: css`
       display: flex;

--- a/src/components/CopyToClipboard/CopyToClipboard.styles.ts
+++ b/src/components/CopyToClipboard/CopyToClipboard.styles.ts
@@ -1,0 +1,27 @@
+import { GrafanaTheme } from '@grafana/data';
+import { css } from 'emotion';
+
+export const getStyles = (theme: GrafanaTheme) => {
+  const { spacing, colors, border } = theme;
+
+  return {
+    tooltip: css`
+      z-index: 1;
+    `,
+    tooltipText: css`
+      display: flex;
+      background-color: ${colors.bg2};
+      border-radius: ${border.radius.md};
+      box-shadow: 0 0 ${spacing.sm} 0 ${colors.dropdownShadow};
+      padding: ${spacing.sm};
+      color: ${colors.text};
+    `,
+    clipboardButton: css`
+      background-color: ${colors.bgBlue1};
+    `,
+    clipboardButtonContainer: css`
+      max-height: fit-content;
+      max-width: fit-content;
+    `,
+  };
+};

--- a/src/components/CopyToClipboard/CopyToClipboard.test.tsx
+++ b/src/components/CopyToClipboard/CopyToClipboard.test.tsx
@@ -9,6 +9,7 @@ const DATA_QA_BUTTON='clipboard-button';
 describe('CopyToClipboard ::', () => {
   test('should render the component', () => {
     const ref = React.createRef<HTMLDivElement>();
+
     render(
       <>
         <CopyToClipboard textContainer={ref}/>
@@ -66,6 +67,7 @@ describe('CopyToClipboard ::', () => {
 
   test('tooltip is automatically hidden after 2000 ms', async () => {
     const ref = React.createRef<HTMLDivElement>();
+
     render(
       <>
         <CopyToClipboard textContainer={ref}/>

--- a/src/components/CopyToClipboard/CopyToClipboard.test.tsx
+++ b/src/components/CopyToClipboard/CopyToClipboard.test.tsx
@@ -1,13 +1,7 @@
 import React from 'react';
-import { act, render, screen, waitForElementToBeRemoved } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { CopyToClipboard } from './CopyToClipboard';
-
-const asyncClick = async (ref) => {
-  await act(async () => {
-    userEvent.click(ref);
-  });
-};
 
 const DATA_QA_TOOLTIP='tooltip';
 const DATA_QA_BUTTON='clipboard-button';
@@ -28,7 +22,7 @@ describe('CopyToClipboard ::', () => {
     expect(screen.getByTestId(DATA_QA_BUTTON)).toBeInTheDocument();
   });
 
-  test('clicking on the button show the tooltip', async () => {
+  test('clicking on the button should show the tooltip', async () => {
     const ref = React.createRef<HTMLDivElement>();
 
     render(
@@ -42,12 +36,12 @@ describe('CopyToClipboard ::', () => {
     const button = await screen.getByTestId(DATA_QA_BUTTON);
 
     expect(screen.queryByTestId(DATA_QA_TOOLTIP)).not.toBeInTheDocument();
-    await asyncClick(button);
+    userEvent.click(button);
 
     expect(screen.queryByTestId(DATA_QA_TOOLTIP)).toBeInTheDocument();
   });
 
-  test('clicking on the button show the tooltip', async () => {
+  test('copyToClipboard should copy the text', async () => {
     const ref = React.createRef<HTMLDivElement>();
 
     render(
@@ -58,12 +52,17 @@ describe('CopyToClipboard ::', () => {
         </div>
       </>,
     );
+    document.execCommand = jest.fn();
+    const copyToClipboardSpy = jest.spyOn(document as any, 'execCommand');
+
     const button = await screen.getByTestId(DATA_QA_BUTTON);
 
     expect(screen.queryByTestId(DATA_QA_TOOLTIP)).not.toBeInTheDocument();
-    await asyncClick(button);
+    userEvent.click(button);
 
     expect(screen.queryByTestId(DATA_QA_TOOLTIP)).toBeInTheDocument();
+
+    expect(copyToClipboardSpy).toHaveBeenCalledWith('copy');
   });
 
   test('tooltip is automatically hidden after 2000 ms', async () => {
@@ -80,13 +79,8 @@ describe('CopyToClipboard ::', () => {
     const button = await screen.getByTestId(DATA_QA_BUTTON);
 
     expect(screen.queryByTestId(DATA_QA_TOOLTIP)).not.toBeInTheDocument();
-    await asyncClick(button);
+    userEvent.click(button);
 
     expect(screen.queryByTestId(DATA_QA_TOOLTIP)).toBeInTheDocument();
-
-    waitForElementToBeRemoved(screen.queryByTestId(DATA_QA_TOOLTIP)).then(() =>
-     expect(screen.queryByTestId(DATA_QA_TOOLTIP)).not.toBeInTheDocument(),
-    );
-
   }, 2000);
 });

--- a/src/components/CopyToClipboard/CopyToClipboard.test.tsx
+++ b/src/components/CopyToClipboard/CopyToClipboard.test.tsx
@@ -9,7 +9,6 @@ const DATA_QA_BUTTON='clipboard-button';
 describe('CopyToClipboard ::', () => {
   test('should render the component', () => {
     const ref = React.createRef<HTMLDivElement>();
-
     render(
       <>
         <CopyToClipboard textContainer={ref}/>
@@ -67,7 +66,6 @@ describe('CopyToClipboard ::', () => {
 
   test('tooltip is automatically hidden after 2000 ms', async () => {
     const ref = React.createRef<HTMLDivElement>();
-
     render(
       <>
         <CopyToClipboard textContainer={ref}/>

--- a/src/components/CopyToClipboard/CopyToClipboard.test.tsx
+++ b/src/components/CopyToClipboard/CopyToClipboard.test.tsx
@@ -3,8 +3,8 @@ import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { CopyToClipboard } from './CopyToClipboard';
 
-const DATA_TESTID='tooltip';
-const DATA_QA_BUTTON='clipboard-button';
+const DATA_TESTID_TOOLTIP='tooltip';
+const DATA_TESTID_BUTTON='clipboard-button';
 
 describe('CopyToClipboard ::', () => {
   test('should render the component', () => {
@@ -35,10 +35,10 @@ describe('CopyToClipboard ::', () => {
     );
     const button = await screen.getByTestId(DATA_TESTID_BUTTON);
 
-    expect(screen.queryByTestId(DATA_TESTID)).not.toBeInTheDocument();
+    expect(screen.queryByTestId(DATA_TESTID_TOOLTIP)).not.toBeInTheDocument();
     userEvent.click(button);
 
-    expect(screen.queryByTestId(DATA_TESTID)).toBeInTheDocument();
+    expect(screen.queryByTestId(DATA_TESTID_TOOLTIP)).toBeInTheDocument();
   });
 
   test('copyToClipboard should copy the text', async () => {
@@ -57,10 +57,10 @@ describe('CopyToClipboard ::', () => {
 
     const button = await screen.getByTestId(DATA_TESTID_BUTTON);
 
-    expect(screen.queryByTestId(DATA_TESTID)).not.toBeInTheDocument();
+    expect(screen.queryByTestId(DATA_TESTID_TOOLTIP)).not.toBeInTheDocument();
     userEvent.click(button);
 
-    expect(screen.queryByTestId(DATA_TESTID)).toBeInTheDocument();
+    expect(screen.queryByTestId(DATA_TESTID_TOOLTIP)).toBeInTheDocument();
 
     expect(copyToClipboardSpy).toHaveBeenCalledWith('copy');
   });
@@ -78,9 +78,9 @@ describe('CopyToClipboard ::', () => {
     );
     const button = await screen.getByTestId(DATA_TESTID_BUTTON);
 
-    expect(screen.queryByTestId(DATA_TESTID)).not.toBeInTheDocument();
+    expect(screen.queryByTestId(DATA_TESTID_TOOLTIP)).not.toBeInTheDocument();
     userEvent.click(button);
 
-    expect(screen.queryByTestId(DATA_TESTID)).toBeInTheDocument();
+    expect(screen.queryByTestId(DATA_TESTID_TOOLTIP)).toBeInTheDocument();
   }, 2000);
 });

--- a/src/components/CopyToClipboard/CopyToClipboard.test.tsx
+++ b/src/components/CopyToClipboard/CopyToClipboard.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { act, render, screen, waitForElementToBeRemoved } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { CopyToClipboard } from "./CopyToClipboard";
+import { CopyToClipboard } from './CopyToClipboard';
 
 const asyncClick = async (ref) => {
   await act(async () => {
@@ -15,13 +15,14 @@ const DATA_QA_BUTTON='clipboard-button';
 describe('CopyToClipboard ::', () => {
   test('should render the component', () => {
     const ref = React.createRef<HTMLDivElement>();
+
     render(
       <>
         <CopyToClipboard textContainer={ref}/>
         <div ref={ref}>
           some text
         </div>
-      </>
+      </>,
     );
 
     expect(screen.getByTestId(DATA_QA_BUTTON)).toBeInTheDocument();
@@ -29,13 +30,14 @@ describe('CopyToClipboard ::', () => {
 
   test('clicking on the button show the tooltip', async () => {
     const ref = React.createRef<HTMLDivElement>();
+
     render(
       <>
         <CopyToClipboard textContainer={ref}/>
         <div ref={ref}>
           some text
         </div>
-      </>
+      </>,
     );
     const button = await screen.getByTestId(DATA_QA_BUTTON);
 
@@ -47,13 +49,14 @@ describe('CopyToClipboard ::', () => {
 
   test('clicking on the button show the tooltip', async () => {
     const ref = React.createRef<HTMLDivElement>();
+
     render(
       <>
         <CopyToClipboard textContainer={ref}/>
         <div ref={ref}>
           some text
         </div>
-      </>
+      </>,
     );
     const button = await screen.getByTestId(DATA_QA_BUTTON);
 
@@ -65,13 +68,14 @@ describe('CopyToClipboard ::', () => {
 
   test('tooltip is automatically hidden after 2000 ms', async () => {
     const ref = React.createRef<HTMLDivElement>();
+
     render(
       <>
         <CopyToClipboard textContainer={ref}/>
         <div ref={ref}>
           some text
         </div>
-      </>
+      </>,
     );
     const button = await screen.getByTestId(DATA_QA_BUTTON);
 
@@ -81,7 +85,7 @@ describe('CopyToClipboard ::', () => {
     expect(screen.queryByTestId(DATA_QA_TOOLTIP)).toBeInTheDocument();
 
     waitForElementToBeRemoved(screen.queryByTestId(DATA_QA_TOOLTIP)).then(() =>
-     expect(screen.queryByTestId(DATA_QA_TOOLTIP)).not.toBeInTheDocument()
+     expect(screen.queryByTestId(DATA_QA_TOOLTIP)).not.toBeInTheDocument(),
     );
 
   }, 2000);

--- a/src/components/CopyToClipboard/CopyToClipboard.test.tsx
+++ b/src/components/CopyToClipboard/CopyToClipboard.test.tsx
@@ -19,7 +19,7 @@ describe('CopyToClipboard ::', () => {
       </>,
     );
 
-    expect(screen.getByTestId(DATA_QA_BUTTON)).toBeInTheDocument();
+    expect(screen.getByTestId(DATA_TESTID_BUTTON)).toBeInTheDocument();
   });
 
   test('clicking on the button should show the tooltip', async () => {
@@ -33,7 +33,7 @@ describe('CopyToClipboard ::', () => {
         </div>
       </>,
     );
-    const button = await screen.getByTestId(DATA_QA_BUTTON);
+    const button = await screen.getByTestId(DATA_TESTID_BUTTON);
 
     expect(screen.queryByTestId(DATA_TESTID)).not.toBeInTheDocument();
     userEvent.click(button);
@@ -55,7 +55,7 @@ describe('CopyToClipboard ::', () => {
     document.execCommand = jest.fn();
     const copyToClipboardSpy = jest.spyOn(document as any, 'execCommand');
 
-    const button = await screen.getByTestId(DATA_QA_BUTTON);
+    const button = await screen.getByTestId(DATA_TESTID_BUTTON);
 
     expect(screen.queryByTestId(DATA_TESTID)).not.toBeInTheDocument();
     userEvent.click(button);
@@ -76,7 +76,7 @@ describe('CopyToClipboard ::', () => {
         </div>
       </>,
     );
-    const button = await screen.getByTestId(DATA_QA_BUTTON);
+    const button = await screen.getByTestId(DATA_TESTID_BUTTON);
 
     expect(screen.queryByTestId(DATA_TESTID)).not.toBeInTheDocument();
     userEvent.click(button);

--- a/src/components/CopyToClipboard/CopyToClipboard.test.tsx
+++ b/src/components/CopyToClipboard/CopyToClipboard.test.tsx
@@ -1,0 +1,88 @@
+import React from 'react';
+import { act, render, screen, waitForElementToBeRemoved } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { CopyToClipboard } from "./CopyToClipboard";
+
+const asyncClick = async (ref) => {
+  await act(async () => {
+    userEvent.click(ref);
+  });
+};
+
+const DATA_QA_TOOLTIP='tooltip';
+const DATA_QA_BUTTON='clipboard-button';
+
+describe('CopyToClipboard ::', () => {
+  test('should render the component', () => {
+    const ref = React.createRef<HTMLDivElement>();
+    render(
+      <>
+        <CopyToClipboard textContainer={ref}/>
+        <div ref={ref}>
+          some text
+        </div>
+      </>
+    );
+
+    expect(screen.getByTestId(DATA_QA_BUTTON)).toBeInTheDocument();
+  });
+
+  test('clicking on the button show the tooltip', async () => {
+    const ref = React.createRef<HTMLDivElement>();
+    render(
+      <>
+        <CopyToClipboard textContainer={ref}/>
+        <div ref={ref}>
+          some text
+        </div>
+      </>
+    );
+    const button = await screen.getByTestId(DATA_QA_BUTTON);
+
+    expect(screen.queryByTestId(DATA_QA_TOOLTIP)).not.toBeInTheDocument();
+    await asyncClick(button);
+
+    expect(screen.queryByTestId(DATA_QA_TOOLTIP)).toBeInTheDocument();
+  });
+
+  test('clicking on the button show the tooltip', async () => {
+    const ref = React.createRef<HTMLDivElement>();
+    render(
+      <>
+        <CopyToClipboard textContainer={ref}/>
+        <div ref={ref}>
+          some text
+        </div>
+      </>
+    );
+    const button = await screen.getByTestId(DATA_QA_BUTTON);
+
+    expect(screen.queryByTestId(DATA_QA_TOOLTIP)).not.toBeInTheDocument();
+    await asyncClick(button);
+
+    expect(screen.queryByTestId(DATA_QA_TOOLTIP)).toBeInTheDocument();
+  });
+
+  test('tooltip is automatically hidden after 2000 ms', async () => {
+    const ref = React.createRef<HTMLDivElement>();
+    render(
+      <>
+        <CopyToClipboard textContainer={ref}/>
+        <div ref={ref}>
+          some text
+        </div>
+      </>
+    );
+    const button = await screen.getByTestId(DATA_QA_BUTTON);
+
+    expect(screen.queryByTestId(DATA_QA_TOOLTIP)).not.toBeInTheDocument();
+    await asyncClick(button);
+
+    expect(screen.queryByTestId(DATA_QA_TOOLTIP)).toBeInTheDocument();
+
+    waitForElementToBeRemoved(screen.queryByTestId(DATA_QA_TOOLTIP)).then(() =>
+     expect(screen.queryByTestId(DATA_QA_TOOLTIP)).not.toBeInTheDocument()
+    );
+
+  }, 2000);
+});

--- a/src/components/CopyToClipboard/CopyToClipboard.test.tsx
+++ b/src/components/CopyToClipboard/CopyToClipboard.test.tsx
@@ -3,7 +3,7 @@ import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { CopyToClipboard } from './CopyToClipboard';
 
-const DATA_QA_TOOLTIP='tooltip';
+const DATA_TESTID='tooltip';
 const DATA_QA_BUTTON='clipboard-button';
 
 describe('CopyToClipboard ::', () => {
@@ -35,10 +35,10 @@ describe('CopyToClipboard ::', () => {
     );
     const button = await screen.getByTestId(DATA_QA_BUTTON);
 
-    expect(screen.queryByTestId(DATA_QA_TOOLTIP)).not.toBeInTheDocument();
+    expect(screen.queryByTestId(DATA_TESTID)).not.toBeInTheDocument();
     userEvent.click(button);
 
-    expect(screen.queryByTestId(DATA_QA_TOOLTIP)).toBeInTheDocument();
+    expect(screen.queryByTestId(DATA_TESTID)).toBeInTheDocument();
   });
 
   test('copyToClipboard should copy the text', async () => {
@@ -57,10 +57,10 @@ describe('CopyToClipboard ::', () => {
 
     const button = await screen.getByTestId(DATA_QA_BUTTON);
 
-    expect(screen.queryByTestId(DATA_QA_TOOLTIP)).not.toBeInTheDocument();
+    expect(screen.queryByTestId(DATA_TESTID)).not.toBeInTheDocument();
     userEvent.click(button);
 
-    expect(screen.queryByTestId(DATA_QA_TOOLTIP)).toBeInTheDocument();
+    expect(screen.queryByTestId(DATA_TESTID)).toBeInTheDocument();
 
     expect(copyToClipboardSpy).toHaveBeenCalledWith('copy');
   });
@@ -78,9 +78,9 @@ describe('CopyToClipboard ::', () => {
     );
     const button = await screen.getByTestId(DATA_QA_BUTTON);
 
-    expect(screen.queryByTestId(DATA_QA_TOOLTIP)).not.toBeInTheDocument();
+    expect(screen.queryByTestId(DATA_TESTID)).not.toBeInTheDocument();
     userEvent.click(button);
 
-    expect(screen.queryByTestId(DATA_QA_TOOLTIP)).toBeInTheDocument();
+    expect(screen.queryByTestId(DATA_TESTID)).toBeInTheDocument();
   }, 2000);
 });

--- a/src/components/CopyToClipboard/CopyToClipboard.tsx
+++ b/src/components/CopyToClipboard/CopyToClipboard.tsx
@@ -1,0 +1,89 @@
+import React, {FC, useCallback, useRef, useState} from 'react';
+import {ClipboardButton, useStyles} from "@grafana/ui";
+import { ButtonProps } from "@grafana/ui/components/Button";
+import { usePopper } from "react-popper";
+import {Options as PopperOptions} from "@popperjs/core/lib/types";
+import { getStyles} from "./CopyToClipboard.styles";
+
+export interface ClipboardIconButtonProps extends ButtonProps {
+  textContainer: React.MutableRefObject<any>;
+}
+
+const popperConfig: Partial<PopperOptions> = {
+  placement: 'auto',
+  modifiers: [
+    {
+      name: 'offset',
+      enabled: true,
+      options: {
+        offset: [0, 10],
+      },
+    },
+  ],
+};
+
+export const CopyToClipboard: FC<ClipboardIconButtonProps> = (props) => {
+  const styles = useStyles(getStyles);
+
+  const { textContainer, ...rest } = props;
+
+  const [tooltipText, setTooltipText] = useState('');
+  const [visible, setVisible] = useState(false);
+
+  const copyToClipboard = useCallback(() => props.textContainer.current?.textContent? props.textContainer.current?.textContent : '', [props.textContainer]);
+
+  const popperRef = useRef(null);
+  const toggleRef = useRef(null);
+
+  const { styles: popperStyles, attributes: popperAttributes } = usePopper(
+    toggleRef.current,
+    popperRef.current,
+    popperConfig,
+  );
+
+  const showTooltip = () => {
+    setVisible(true);
+    setTimeout(() => setVisible(false), 2000);
+  }
+
+  const onClipboardCopy = () => {
+    setTooltipText('Text copied to clipboard');
+    showTooltip();
+  }
+
+  const onClipboardError = () => {
+    setTooltipText('Text not copied to clipboard');
+    showTooltip();
+  }
+
+  return (
+    <>
+      <div className={styles.clipboardButtonContainer} ref={toggleRef} >
+        <ClipboardButton
+          {...rest}
+          className={styles.clipboardButton}
+          onClipboardCopy={onClipboardCopy}
+          onClipboardError={onClipboardError}
+          getText={copyToClipboard}
+          icon="copy"/>
+      </div>
+      <div
+        ref={popperRef}
+        style={popperStyles.popper}
+        className={styles.tooltip}
+        {...popperAttributes.popper}
+        data-testid="tooltip-container"
+      >
+        {visible ? (
+          <div
+            className={styles.tooltipText}
+            style={popperStyles.offset}
+            data-testid="tooltip"
+          >
+            {tooltipText}
+          </div>
+        ) : null}
+      </div>
+    </>
+  )
+};

--- a/src/components/CopyToClipboard/CopyToClipboard.tsx
+++ b/src/components/CopyToClipboard/CopyToClipboard.tsx
@@ -65,6 +65,7 @@ export const CopyToClipboard: FC<ClipboardIconButtonProps> = (props) => {
           onClipboardCopy={onClipboardCopy}
           onClipboardError={onClipboardError}
           getText={copyToClipboard}
+          data-testid="clipboard-button"
           icon="copy"/>
       </div>
       <div

--- a/src/components/CopyToClipboard/CopyToClipboard.tsx
+++ b/src/components/CopyToClipboard/CopyToClipboard.tsx
@@ -1,9 +1,9 @@
 import React, {FC, useCallback, useRef, useState} from 'react';
-import {ClipboardButton, useStyles} from "@grafana/ui";
-import { ButtonProps } from "@grafana/ui/components/Button";
-import { usePopper } from "react-popper";
-import {Options as PopperOptions} from "@popperjs/core/lib/types";
-import { getStyles} from "./CopyToClipboard.styles";
+import { ClipboardButton, useStyles } from '@grafana/ui';
+import { ButtonProps } from '@grafana/ui/components/Button';
+import { usePopper } from 'react-popper';
+import { Options as PopperOptions } from '@popperjs/core/lib/types';
+import { getStyles } from './CopyToClipboard.styles';
 
 export interface ClipboardIconButtonProps extends ButtonProps {
   textContainer: React.MutableRefObject<any>;
@@ -30,7 +30,7 @@ export const CopyToClipboard: FC<ClipboardIconButtonProps> = (props) => {
   const [tooltipText, setTooltipText] = useState('');
   const [visible, setVisible] = useState(false);
 
-  const copyToClipboard = useCallback(() => props.textContainer.current?.textContent? props.textContainer.current?.textContent : '', [props.textContainer]);
+  const copyToClipboard = useCallback(() => textContainer.current?.textContent? textContainer.current?.textContent : '', [textContainer]);
 
   const popperRef = useRef(null);
   const toggleRef = useRef(null);
@@ -44,17 +44,17 @@ export const CopyToClipboard: FC<ClipboardIconButtonProps> = (props) => {
   const showTooltip = () => {
     setVisible(true);
     setTimeout(() => setVisible(false), 2000);
-  }
+  };
 
   const onClipboardCopy = () => {
     setTooltipText('Text copied to clipboard');
     showTooltip();
-  }
+  };
 
   const onClipboardError = () => {
     setTooltipText('Text not copied to clipboard');
     showTooltip();
-  }
+  };
 
   return (
     <>
@@ -86,5 +86,5 @@ export const CopyToClipboard: FC<ClipboardIconButtonProps> = (props) => {
         ) : null}
       </div>
     </>
-  )
+  );
 };

--- a/src/components/CopyToClipboard/CopyToClipboard.tsx
+++ b/src/components/CopyToClipboard/CopyToClipboard.tsx
@@ -1,4 +1,4 @@
-import React, {FC, useCallback, useRef, useState} from 'react';
+import React, {FC, useCallback, useEffect, useRef, useState} from 'react';
 import { ClipboardButton, useStyles } from '@grafana/ui';
 import { ButtonProps } from '@grafana/ui/components/Button';
 import { usePopper } from 'react-popper';
@@ -30,7 +30,8 @@ export const CopyToClipboard: FC<ClipboardIconButtonProps> = (props) => {
   const [tooltipText, setTooltipText] = useState('');
   const [visible, setVisible] = useState(false);
 
-  const copyToClipboard = useCallback(() => textContainer.current?.textContent? textContainer.current?.textContent : '', [textContainer]);
+  const copyToClipboard = useCallback(() => textContainer.current?.textContent ?
+    textContainer.current?.textContent : '', [textContainer]);
 
   const popperRef = useRef(null);
   const toggleRef = useRef(null);
@@ -41,20 +42,23 @@ export const CopyToClipboard: FC<ClipboardIconButtonProps> = (props) => {
     popperConfig,
   );
 
-  const showTooltip = () => {
-    setVisible(true);
-    setTimeout(() => setVisible(false), 2000);
-  };
-
   const onClipboardCopy = () => {
     setTooltipText('Text copied to clipboard');
-    showTooltip();
+    setVisible(true);
   };
 
   const onClipboardError = () => {
-    setTooltipText('Text not copied to clipboard');
-    showTooltip();
+    setTooltipText('Couldn\'t copy text to clipboard');
+    setVisible(true);
   };
+
+  useEffect(()=> {
+    const timer = setTimeout(() => visible && setVisible(false), 2000);
+
+    return () => {
+      clearTimeout(timer);
+    };
+  }, [visible]);
 
   return (
     <>

--- a/src/components/CopyToClipboard/CopyToClipboard.tsx
+++ b/src/components/CopyToClipboard/CopyToClipboard.tsx
@@ -1,4 +1,4 @@
-import React, {FC, useCallback, useEffect, useRef, useState} from 'react';
+import React, { FC, useCallback, useEffect, useRef, useState } from 'react';
 import { ClipboardButton, useStyles } from '@grafana/ui';
 import { ButtonProps } from '@grafana/ui/components/Button';
 import { usePopper } from 'react-popper';

--- a/src/components/CopyToClipboard/CopyToClipboard.tsx
+++ b/src/components/CopyToClipboard/CopyToClipboard.tsx
@@ -7,9 +7,10 @@ import { getStyles } from './CopyToClipboard.styles';
 
 export interface ClipboardIconButtonProps extends ButtonProps {
   textContainer: React.MutableRefObject<HTMLElement | null>;
+  popperConfig?: Partial<PopperOptions>;
 }
 
-const popperConfig: Partial<PopperOptions> = {
+const defaultPopperConfig: Partial<PopperOptions> = {
   placement: 'auto',
   modifiers: [
     {
@@ -22,7 +23,7 @@ const popperConfig: Partial<PopperOptions> = {
   ],
 };
 
-export const CopyToClipboard: FC<ClipboardIconButtonProps> = ({ textContainer, ...rest }) => {
+export const CopyToClipboard: FC<ClipboardIconButtonProps> = ({ textContainer, popperConfig, ...rest }) => {
   const styles = useStyles(getStyles);
 
   const [tooltipText, setTooltipText] = useState('');
@@ -36,7 +37,7 @@ export const CopyToClipboard: FC<ClipboardIconButtonProps> = ({ textContainer, .
   const { styles: popperStyles, attributes: popperAttributes } = usePopper(
     toggleRef.current,
     popperRef.current,
-    popperConfig,
+    {...defaultPopperConfig, ...popperConfig},
   );
 
   const onClipboardCopy = () => {
@@ -59,7 +60,7 @@ export const CopyToClipboard: FC<ClipboardIconButtonProps> = ({ textContainer, .
 
   return (
     <>
-      <div className={styles.clipboardButtonContainer} ref={toggleRef} >
+      <div className={styles.clipboardButtonContainer} ref={toggleRef} onClick={(e) => e.preventDefault()} >
         <ClipboardButton
           {...rest}
           className={styles.clipboardButton}

--- a/src/components/CopyToClipboard/CopyToClipboard.tsx
+++ b/src/components/CopyToClipboard/CopyToClipboard.tsx
@@ -6,7 +6,7 @@ import { Options as PopperOptions } from '@popperjs/core/lib/types';
 import { getStyles } from './CopyToClipboard.styles';
 
 export interface ClipboardIconButtonProps extends ButtonProps {
-  textContainer: React.MutableRefObject<any>;
+  textContainer: React.MutableRefObject<HTMLElement | null>;
 }
 
 const popperConfig: Partial<PopperOptions> = {

--- a/src/components/CopyToClipboard/CopyToClipboard.tsx
+++ b/src/components/CopyToClipboard/CopyToClipboard.tsx
@@ -22,16 +22,13 @@ const popperConfig: Partial<PopperOptions> = {
   ],
 };
 
-export const CopyToClipboard: FC<ClipboardIconButtonProps> = (props) => {
+export const CopyToClipboard: FC<ClipboardIconButtonProps> = ({ textContainer, ...rest}) => {
   const styles = useStyles(getStyles);
-
-  const { textContainer, ...rest } = props;
 
   const [tooltipText, setTooltipText] = useState('');
   const [visible, setVisible] = useState(false);
 
-  const copyToClipboard = useCallback(() => textContainer.current?.textContent ?
-    textContainer.current?.textContent : '', [textContainer]);
+  const copyToClipboard = useCallback(() => textContainer.current?.textContent || '', [textContainer]);
 
   const popperRef = useRef(null);
   const toggleRef = useRef(null);

--- a/src/components/CopyToClipboard/CopyToClipboard.tsx
+++ b/src/components/CopyToClipboard/CopyToClipboard.tsx
@@ -22,7 +22,7 @@ const popperConfig: Partial<PopperOptions> = {
   ],
 };
 
-export const CopyToClipboard: FC<ClipboardIconButtonProps> = ({ textContainer, ...rest}) => {
+export const CopyToClipboard: FC<ClipboardIconButtonProps> = ({ textContainer, ...rest }) => {
   const styles = useStyles(getStyles);
 
   const [tooltipText, setTooltipText] = useState('');

--- a/src/components/CopyToClipboard/CopyToClipboard.tsx
+++ b/src/components/CopyToClipboard/CopyToClipboard.tsx
@@ -1,9 +1,9 @@
 import React, { FC, useCallback, useEffect, useRef, useState } from 'react';
 import { ClipboardButton, useStyles } from '@grafana/ui';
-import { ButtonProps } from '@grafana/ui/components/Button';
 import { usePopper } from 'react-popper';
 import { Options as PopperOptions } from '@popperjs/core/lib/types';
 import { getStyles } from './CopyToClipboard.styles';
+import { ButtonProps } from '../LoaderButton';
 
 export interface ClipboardIconButtonProps extends ButtonProps {
   textContainer: React.MutableRefObject<HTMLElement | null>;

--- a/src/components/CopyToClipboard/index.ts
+++ b/src/components/CopyToClipboard/index.ts
@@ -1,0 +1,1 @@
+export * from './CopyToClipboard';

--- a/src/components/LoaderButton/LoaderButton.tsx
+++ b/src/components/LoaderButton/LoaderButton.tsx
@@ -12,7 +12,7 @@ type CommonProps = {
   fullWidth?: boolean;
 };
 
-type ButtonProps = CommonProps & ButtonHTMLAttributes<HTMLButtonElement>;
+export type ButtonProps = CommonProps & ButtonHTMLAttributes<HTMLButtonElement>;
 
 export interface LoaderButtonProps extends ButtonProps {
   loading?: boolean;

--- a/src/components/Table/Table.tsx
+++ b/src/components/Table/Table.tsx
@@ -2,12 +2,12 @@ import React, { FC } from 'react';
 import { useTable, usePagination, useExpanded } from 'react-table';
 import { css } from 'emotion';
 import { useStyles } from '@grafana/ui';
-import { Overlay } from '..';
 import { getStyles } from './Table.styles';
 import { TableProps, PaginatedTableInstance, PaginatedTableOptions, PaginatedTableState } from './Table.types';
 import { Pagination } from './Pagination';
 import { PAGE_SIZES } from './Pagination/Pagination.constants';
 import { TableContent } from './TableContent';
+import { Overlay } from "../Overlay";
 
 const defaultPropGetter = () => ({});
 

--- a/src/components/Table/Table.tsx
+++ b/src/components/Table/Table.tsx
@@ -7,7 +7,7 @@ import { TableProps, PaginatedTableInstance, PaginatedTableOptions, PaginatedTab
 import { Pagination } from './Pagination';
 import { PAGE_SIZES } from './Pagination/Pagination.constants';
 import { TableContent } from './TableContent';
-import { Overlay } from "../Overlay";
+import { Overlay } from '../Overlay';
 
 const defaultPropGetter = () => ({});
 

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -13,3 +13,4 @@ export * from './Table';
 export * from './TableToolbar';
 export * from './NumberInput';
 export * from './Label';
+export * from './CopyToClipboard';


### PR DESCRIPTION
What this PR does / why we need it:
We need a modified, icon-only, version of the Grafana’s ClipboardButton component. 

Which issue(s) this PR fixes:
https://jira.percona.com/browse/PMM-9081
![image](https://user-images.githubusercontent.com/90199600/139844466-40a68548-5d36-415c-94da-1d511cfd7623.png)
![image](https://user-images.githubusercontent.com/90199600/139844300-bcbeb7e5-158b-4d79-bf27-4181329ecf20.png)
