### PR TITLE
PMM-9481 Pagination: moving Pagination from grafana, fixing lint errors

### DIFF
--- a/src/components/Pagination/Pagination.constants.ts
+++ b/src/components/Pagination/Pagination.constants.ts
@@ -1,0 +1,16 @@
+import { SelectableValue } from '@grafana/data';
+
+export const PAGE_SIZES: Array<SelectableValue<number>> = [
+  {
+    label: '25',
+    value: 25,
+  },
+  {
+    label: '50',
+    value: 50,
+  },
+  {
+    label: '100',
+    value: 100,
+  },
+];

--- a/src/components/Pagination/Pagination.hooks.test.tsx
+++ b/src/components/Pagination/Pagination.hooks.test.tsx
@@ -1,0 +1,71 @@
+import React, { FC } from 'react';
+import { render, fireEvent } from '@testing-library/react';
+import { PAGE_SIZES } from './Pagination.constants';
+import { useStoredTablePageSize } from './Pagination.hooks';
+
+const TABLE_ID = 'test-id';
+const TABLE_STORAGE_ID = `${TABLE_ID}-table-page-size`;
+const DEFAULT_VALUE = PAGE_SIZES[0].value;
+
+const TestComponent: FC = () => {
+  const [pageSize, setPageSize] = useStoredTablePageSize(TABLE_ID);
+
+  return (
+    <>
+      <span>{pageSize}</span>
+      <input type="number" value={pageSize} onChange={(e) => setPageSize(parseInt(e.target.value, 10))} />
+    </>
+  );
+};
+
+const getDataFromLocalStorage = (): number => parseInt(localStorage.getItem(TABLE_STORAGE_ID) || '0', 10);
+
+const setDataOnLocalStorage = (pageSize: number) => localStorage.setItem(TABLE_STORAGE_ID, `${pageSize}`);
+
+describe('useStoredTablePageSize', () => {
+  beforeAll(() => {
+    localStorage.removeItem(TABLE_STORAGE_ID);
+  });
+  afterAll(() => {
+    localStorage.removeItem(TABLE_STORAGE_ID);
+  });
+
+  it('should initially store the default pageSize', () => {
+    render(<TestComponent />);
+    const storedSize = getDataFromLocalStorage();
+
+    expect(storedSize).toBe(DEFAULT_VALUE);
+    localStorage.removeItem(TABLE_STORAGE_ID);
+  });
+
+  it('should store the size on local storage after input changes', () => {
+    const { container } = render(<TestComponent />);
+    const input = container.querySelectorAll('input')[0];
+    const { value } = PAGE_SIZES[1];
+
+    fireEvent.change(input, { target: { value } });
+    const storedSize = getDataFromLocalStorage();
+
+    expect(storedSize).toBe(value);
+  });
+
+  it('should set the size from previous saves', () => {
+    const value = PAGE_SIZES[1].value || 0;
+
+    setDataOnLocalStorage(value);
+    const { container } = render(<TestComponent />);
+    const span = container.querySelectorAll('span')[0];
+
+    expect(span).toHaveTextContent(value.toString());
+  });
+
+  it('should set the default if a wrong value is saved', () => {
+    localStorage.setItem(TABLE_STORAGE_ID, '1a');
+    const { container } = render(<TestComponent />);
+    const spanText = container.querySelectorAll('span')[0].textContent;
+    const storedSize = getDataFromLocalStorage();
+
+    expect(spanText ? +spanText : spanText).toBe(DEFAULT_VALUE);
+    expect(storedSize).toBe(DEFAULT_VALUE);
+  });
+});

--- a/src/components/Pagination/Pagination.hooks.ts
+++ b/src/components/Pagination/Pagination.hooks.ts
@@ -1,0 +1,30 @@
+import { useEffect, useState } from 'react';
+import { logger } from '../../shared';
+import { PAGE_SIZES } from './Pagination.constants';
+
+export const getPageSize = (pageSize: number) =>
+  PAGE_SIZES.find((size) => size.value === pageSize) ? pageSize : (PAGE_SIZES[0].value as number);
+
+export const useStoredTablePageSize = (tableId: string) => {
+  let pageSize = PAGE_SIZES[0].value as number;
+  const fullId = `${tableId}-table-page-size`;
+
+  try {
+    const storedValue = parseInt(localStorage.getItem(fullId) as string, 10);
+
+    if (storedValue && !Number.isNaN(storedValue)) {
+      pageSize = storedValue;
+    }
+  } catch (e) {
+    logger.error(e);
+  }
+  const [value, setValue] = useState(getPageSize(pageSize));
+
+  useEffect(() => {
+    if (tableId) {
+      localStorage.setItem(fullId, `${value}`);
+    }
+  }, [value, fullId, tableId]);
+
+  return [value, setValue] as const;
+};

--- a/src/components/Pagination/Pagination.messages.ts
+++ b/src/components/Pagination/Pagination.messages.ts
@@ -1,0 +1,5 @@
+export const Messages = {
+  rowsPerPage: 'Rows per page: ',
+  getItemsIntervalMessage: (leftNumber: number, rightNumber: number, totalItems: number) =>
+    `Showing ${leftNumber}-${rightNumber} of ${totalItems} items`,
+};

--- a/src/components/Pagination/Pagination.stories.tsx
+++ b/src/components/Pagination/Pagination.stories.tsx
@@ -1,0 +1,33 @@
+import React from 'react';
+import { ComponentStory, ComponentMeta } from '@storybook/react';
+import { SelectableValue } from '@grafana/data';
+import { Pagination } from './Pagination';
+
+const options: Array<SelectableValue<number>> = [
+  {
+    label: '50',
+    value: 50,
+  },
+  {
+    label: '100',
+    value: 100,
+  },
+];
+
+export default {
+  title: 'Overlays/Pagination',
+  component: Pagination,
+  decorators: [(Story) => <Story />],
+} as ComponentMeta<typeof Pagination>;
+
+const Template: ComponentStory<typeof Pagination> = (args) => <Pagination {...args} />;
+
+export const Basic = Template.bind({});
+Basic.args = {
+  pagesPerView: 3,
+  totalItems: 15,
+  pageCount: 5,
+  pageSizeOptions: options,
+  pageSize: 3,
+  nrRowsOnCurrentPage: 3,
+};

--- a/src/components/Pagination/Pagination.styles.ts
+++ b/src/components/Pagination/Pagination.styles.ts
@@ -1,0 +1,41 @@
+import { css } from '@emotion/css';
+import { GrafanaTheme2 } from '@grafana/data';
+
+export const getStyles = ({ v1: { spacing } }: GrafanaTheme2) => ({
+  pagination: css`
+    display: flex;
+    justify-content: space-between;
+    padding-top: ${spacing.md};
+
+    & > span:first-child {
+      padding-left: ${spacing.md};
+    }
+  `,
+  pageButtonsContainer: css`
+    & > span:first-child {
+      margin-right: ${spacing.xl};
+    }
+
+    & > span:last-child {
+      white-space: nowrap;
+    }
+
+    button {
+      width: 35px;
+      justify-content: center;
+      &:not(:last-child) {
+        margin-right: ${spacing.sm};
+      }
+    },
+  `,
+  pageSizeContainer: css`
+    & > span:first-child {
+      margin-right: ${spacing.md};
+    }
+
+    & > span:last-child {
+      display: inline-block;
+      width: 70px;
+    }
+  `,
+});

--- a/src/components/Pagination/Pagination.test.tsx
+++ b/src/components/Pagination/Pagination.test.tsx
@@ -1,0 +1,359 @@
+import React from 'react';
+import { SelectableValue } from '@grafana/data';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { Pagination } from './Pagination';
+import { Messages } from './Pagination.messages';
+
+describe('Pagination', () => {
+  it('should render at least one page', () => {
+    render(
+      <Pagination totalItems={0} pageCount={1} pageSizeOptions={[]} pageSize={3} nrRowsOnCurrentPage={0} />,
+    );
+    expect(screen.getByTestId('page-button-active')).toBeInTheDocument();
+    expect(screen.queryByTestId('page-button')).not.toBeInTheDocument();
+  });
+
+  it('should disable left navigation buttons when in first page', () => {
+    render(
+      <Pagination totalItems={30} pageCount={10} pageSizeOptions={[]} pageSize={3} nrRowsOnCurrentPage={3} />,
+    );
+    expect(screen.getByTestId('previous-page-button')).toBeDisabled();
+    expect(screen.getByTestId('first-page-button')).toBeDisabled();
+  });
+
+  it('should disable right navigation buttons when in last page', () => {
+    render(
+      <Pagination
+        totalItems={10}
+        pageCount={1}
+        pageSizeOptions={[]}
+        pageSize={10}
+        nrRowsOnCurrentPage={10}
+      />,
+    );
+    expect(screen.getByTestId('next-page-button')).toBeDisabled();
+    expect(screen.getByTestId('last-page-button')).toBeDisabled();
+  });
+
+  it('should enable all navigation buttons while active page is not first or last', () => {
+    render(
+      <Pagination
+        totalItems={30}
+        pageCount={3}
+        pageSizeOptions={[]}
+        pageSize={10}
+        nrRowsOnCurrentPage={10}
+      />,
+    );
+    const nextPageButton = screen.getByTestId('next-page-button');
+
+    fireEvent.click(nextPageButton);
+
+    expect(screen.getByTestId('previous-page-button')).not.toBeDisabled();
+    expect(screen.getByTestId('first-page-button')).not.toBeDisabled();
+    expect(screen.getByTestId('next-page-button')).not.toBeDisabled();
+    expect(screen.getByTestId('last-page-button')).not.toBeDisabled();
+  });
+
+  it('should show all pages when pagesPerView > totalPages', () => {
+    render(
+      <Pagination
+        pagesPerView={25}
+        totalItems={10}
+        pageCount={4}
+        pageSizeOptions={[]}
+        pageSize={3}
+        nrRowsOnCurrentPage={3}
+      />,
+    );
+    expect(screen.getAllByTestId('page-button')).toHaveLength(3);
+    expect(screen.getAllByTestId('page-button-active')).toHaveLength(1);
+  });
+
+  it('should show "pagesPerView" pages if pageCount > pagesPerView', () => {
+    render(
+      <Pagination
+        pagesPerView={5}
+        totalItems={100}
+        pageCount={10}
+        pageSizeOptions={[]}
+        pageSize={10}
+        nrRowsOnCurrentPage={10}
+      />,
+    );
+    expect(screen.getAllByTestId('page-button')).toHaveLength(4);
+    expect(screen.getAllByTestId('page-button-active')).toHaveLength(1);
+  });
+
+  it('should keep the selected page in the center, when pagesPerView is odd and while last page button is not visible', async () => {
+    render(
+      <Pagination
+        pagesPerView={5}
+        totalItems={20}
+        pageCount={7}
+        pageSizeOptions={[]}
+        pageSize={3}
+        nrRowsOnCurrentPage={3}
+      />,
+    );
+    // There's 7 pages, meaning two clicks will get us to page 3, in the very center
+    // Two more clicks should bring 4 and 5 to the center as well
+    for (let i = 0; i < 2; i += 1) {
+      const btn = screen.getByTestId('next-page-button');
+
+      fireEvent.click(btn);
+    }
+
+    expect(screen.getByTestId('page-button-active')).toHaveTextContent('3');
+
+    for (let i = 0; i < 2; i += 1) {
+      const btn = screen.getByTestId('next-page-button');
+
+      fireEvent.click(btn);
+    }
+
+    expect(screen.getByTestId('page-button-active')).toHaveTextContent('5');
+  });
+
+  it('should keep the selected page in the center-left, when pagesPerView is even and while last page button is not visible', async () => {
+    render(
+      <Pagination
+        pagesPerView={6}
+        totalItems={80}
+        pageCount={8}
+        pageSizeOptions={[]}
+        pageSize={10}
+        nrRowsOnCurrentPage={10}
+      />,
+    );
+    // There's 8 pages, meaning two clicks will get us to page 3, in the center-left
+    // Two more clicks should bring 4 and 5 to that same position
+    for (let i = 0; i < 2; i += 1) {
+      const btn = screen.getByTestId('next-page-button');
+
+      fireEvent.click(btn);
+    }
+
+    expect(screen.getByTestId('page-button-active')).toHaveTextContent('3');
+
+    for (let i = 0; i < 2; i += 1) {
+      const btn = screen.getByTestId('next-page-button');
+
+      fireEvent.click(btn);
+    }
+
+    expect(screen.getByTestId('page-button-active')).toHaveTextContent('5');
+  });
+
+  it('should keep moving from the center when last page button is already visible', async () => {
+    render(
+      <Pagination
+        pagesPerView={3}
+        totalItems={15}
+        pageCount={5}
+        pageSizeOptions={[]}
+        pageSize={3}
+        nrRowsOnCurrentPage={3}
+      />,
+    );
+    // There's 5 pages and 3 pages/view, meaning two clicks will bring the last page button into the view
+    // After that, any click should move the active page button towards the end, instead of keeping in the center
+    // That means that with 4 clicks, we should have page 5 selected on the right
+    for (let i = 0; i < 4; i += 1) {
+      const btn = screen.getByTestId('next-page-button');
+
+      fireEvent.click(btn);
+    }
+
+    expect(screen.getByTestId('page-button-active')).toHaveTextContent('5');
+  });
+
+  it('should correctly show the items interval being shown', async () => {
+    render(
+      <Pagination
+        pagesPerView={3}
+        totalItems={15}
+        pageCount={5}
+        pageSizeOptions={[]}
+        pageSize={3}
+        nrRowsOnCurrentPage={3}
+      />,
+    );
+    expect(screen.getByTestId('pagination-items-inverval')).toHaveTextContent(
+      Messages.getItemsIntervalMessage(1, 3, 15),
+    );
+    for (let i = 0; i < 2; i += 1) {
+      const btn = screen.getByTestId('next-page-button');
+
+      fireEvent.click(btn);
+    }
+
+    expect(screen.getByTestId('pagination-items-inverval')).toHaveTextContent(
+      Messages.getItemsIntervalMessage(7, 9, 15),
+    );
+  });
+
+  it('should show "showing 0 - 0 of 0 items" when empty', () => {
+    render(
+      <Pagination
+        pagesPerView={3}
+        totalItems={0}
+        pageCount={0}
+        pageSizeOptions={[]}
+        pageSize={3}
+        nrRowsOnCurrentPage={0}
+      />,
+    );
+    expect(screen.getByTestId('pagination-items-inverval')).toHaveTextContent(
+      Messages.getItemsIntervalMessage(0, 0, 0),
+    );
+  });
+
+  it('should trigger a page change', () => {
+    const cb = jest.fn();
+
+    render(
+      <Pagination
+        pagesPerView={3}
+        totalItems={15}
+        pageCount={5}
+        pageSizeOptions={[]}
+        pageSize={3}
+        nrRowsOnCurrentPage={3}
+        onPageChange={cb}
+      />,
+    );
+    const btn = screen.getByTestId('next-page-button');
+
+    fireEvent.click(btn);
+    expect(cb).toBeCalledWith(1);
+  });
+
+  it('should not trigger a page change on first page and previous is clicked', () => {
+    const cb = jest.fn();
+
+    render(
+      <Pagination
+        pagesPerView={3}
+        totalItems={15}
+        pageCount={5}
+        pageSizeOptions={[]}
+        pageSize={3}
+        nrRowsOnCurrentPage={3}
+        onPageChange={cb}
+      />,
+    );
+    const btn = screen.getByTestId('previous-page-button');
+
+    fireEvent.click(btn);
+    expect(cb).not.toHaveBeenCalled();
+  });
+
+  it('should not trigger a page change if on last page and next is clicked', () => {
+    const cb = jest.fn();
+
+    render(
+      <Pagination
+        pagesPerView={3}
+        totalItems={15}
+        pageCount={5}
+        pageSizeOptions={[]}
+        pageSize={3}
+        nrRowsOnCurrentPage={3}
+        onPageChange={cb}
+      />,
+    );
+    for (let i = 0; i < 5; i += 1) {
+      const btn = screen.getByTestId('next-page-button');
+
+      fireEvent.click(btn);
+    }
+
+    expect(cb).toHaveBeenCalledTimes(4);
+  });
+
+  it('should jump to last page', () => {
+    render(
+      <Pagination
+        pagesPerView={3}
+        totalItems={15}
+        pageCount={5}
+        pageSizeOptions={[]}
+        pageSize={3}
+        nrRowsOnCurrentPage={3}
+      />,
+    );
+    const btn = screen.getByTestId('last-page-button');
+
+    fireEvent.click(btn);
+
+    expect(screen.getByTestId('page-button-active')).toHaveTextContent('5');
+  });
+
+  it('should jump to first page', () => {
+    render(
+      <Pagination
+        pagesPerView={3}
+        totalItems={15}
+        pageCount={5}
+        pageSizeOptions={[]}
+        pageSize={3}
+        nrRowsOnCurrentPage={3}
+      />,
+    );
+    for (let i = 0; i < 5; i += 1) {
+      const btn = screen.getByTestId('next-page-button');
+
+      fireEvent.click(btn);
+    }
+
+    const btn = screen.getByTestId('first-page-button');
+
+    fireEvent.click(btn);
+
+    expect(screen.getByTestId('page-button-active')).toHaveTextContent('1');
+  });
+
+  it('should go to first page after page size changes', () => {
+    const cb = jest.fn();
+    const options: Array<SelectableValue<number>> = [
+      {
+        label: '50',
+        value: 50,
+      },
+      {
+        label: '100',
+        value: 100,
+      },
+    ];
+
+    render(
+      <Pagination
+        pagesPerView={3}
+        totalItems={15}
+        pageCount={5}
+        pageSizeOptions={options}
+        pageSize={3}
+        nrRowsOnCurrentPage={3}
+        onPageChange={jest.fn()}
+        onPageSizeChange={cb}
+      />,
+    );
+    for (let i = 0; i < 5; i += 1) {
+      const btn = screen.getByTestId('next-page-button');
+
+      fireEvent.click(btn);
+    }
+
+    const input = screen.getAllByRole('textbox')[0];
+
+    fireEvent.keyDown(input, { key: 'ArrowDown' });
+
+    const optionsArray = screen.getAllByLabelText('Select option');
+
+    fireEvent.click(optionsArray[optionsArray.length - 1]);
+
+    expect(cb).toHaveBeenCalledWith(100);
+    expect(screen.getByTestId('page-button-active')).toHaveTextContent('1');
+  });
+});

--- a/src/components/Pagination/Pagination.tsx
+++ b/src/components/Pagination/Pagination.tsx
@@ -1,0 +1,104 @@
+import React, { FC, useState, useMemo } from 'react';
+import { useStyles2, IconName, Button, Select } from '@grafana/ui';
+import { PaginationProps } from './Pagination.types';
+import { getStyles } from './Pagination.styles';
+import { Messages } from './Pagination.messages';
+import { getShownPages, getLeftItemNumber, getRightItemNumber } from './Pagination.utils';
+
+export const Pagination: FC<PaginationProps> = ({
+  pageCount = 1,
+  initialPageIndex = 0,
+  pageSize,
+  pagesPerView = 3,
+  nrRowsOnCurrentPage,
+  totalItems = 0,
+  pageSizeOptions,
+  onPageChange = () => 0,
+  onPageSizeChange = () => 0,
+}) => {
+  const [activePageIndex, setActivePageIndex] = useState(initialPageIndex);
+  // @ts-ignore
+  const pageArray = useMemo(() => [...Array(pageCount).keys()], [pageCount]);
+  // We want to center our selected page, thus we need to know how many should be on the left
+  const shownPages = getShownPages(pageArray, activePageIndex, pagesPerView);
+  const leftItemNumber = getLeftItemNumber(pageCount, activePageIndex, pageSize);
+  const rightItemNumber = getRightItemNumber(activePageIndex, pageSize, nrRowsOnCurrentPage);
+  const style = useStyles2(getStyles);
+
+  const gotoPage = (pageIndex: number) => {
+    const index = Math.max(0, Math.min(pageIndex, pageCount - 1));
+
+    if (index !== activePageIndex) {
+      setActivePageIndex(index);
+      onPageChange(index);
+    }
+  };
+
+  const pageSizeChanged = (size: number) => {
+    onPageSizeChange(size);
+    setActivePageIndex(0);
+  };
+
+  return (
+    <div className={style.pagination} data-testid="pagination">
+      <span className={style.pageSizeContainer}>
+        <span>{Messages.rowsPerPage}</span>
+        <span>
+          <Select
+            data-testid="pagination-size-select"
+            isSearchable={false}
+            value={pageSize}
+            options={pageSizeOptions}
+            onChange={(e) => pageSizeChanged(e.value || 0)}
+          />
+        </span>
+      </span>
+      <span className={style.pageButtonsContainer}>
+        <span data-testid="pagination-items-inverval">
+          {Messages.getItemsIntervalMessage(leftItemNumber, rightItemNumber, totalItems)}
+        </span>
+        <span>
+          <Button
+            data-testid="first-page-button"
+            icon={'angle-double-left' as IconName}
+            variant="secondary"
+            disabled={activePageIndex === 0}
+            onClick={() => gotoPage(0)}
+          />
+          <Button
+            data-testid="previous-page-button"
+            icon="angle-left"
+            variant="secondary"
+            disabled={activePageIndex === 0}
+            onClick={() => gotoPage(activePageIndex - 1)}
+          />
+          {shownPages.map((page) => (
+            <Button
+              data-testid={`page-button${activePageIndex === page ? '-active' : ''}`}
+              variant={activePageIndex === page ? 'primary' : 'secondary'}
+              onClick={() => gotoPage(page)}
+              key={page}
+            >
+              {page + 1}
+            </Button>
+          ))}
+          <Button
+            data-testid="next-page-button"
+            icon="angle-right"
+            variant="secondary"
+            disabled={activePageIndex === pageCount - 1}
+            onClick={() => gotoPage(activePageIndex + 1)}
+            className="next-page"
+          />
+          <Button
+            data-testid="last-page-button"
+            icon={'angle-double-right' as IconName}
+            variant="secondary"
+            disabled={activePageIndex === pageCount - 1}
+            onClick={() => gotoPage(pageCount - 1)}
+          />
+        </span>
+      </span>
+    </div>
+  );
+};

--- a/src/components/Pagination/Pagination.types.ts
+++ b/src/components/Pagination/Pagination.types.ts
@@ -1,0 +1,13 @@
+import { SelectableValue } from '@grafana/data';
+
+export interface PaginationProps {
+  totalItems: number;
+  pageCount: number;
+  initialPageIndex?: number;
+  pagesPerView?: number;
+  pageSizeOptions: Array<SelectableValue<number>>;
+  pageSize: number;
+  nrRowsOnCurrentPage: number;
+  onPageChange?: (pageIndex: number) => void;
+  onPageSizeChange?: (size: number) => void;
+}

--- a/src/components/Pagination/Pagination.utils.test.ts
+++ b/src/components/Pagination/Pagination.utils.test.ts
@@ -1,0 +1,30 @@
+import { getShownPages, getLeftItemNumber, getRightItemNumber } from './Pagination.utils';
+
+describe('Pagination::utils', () => {
+  test('getShownPages', () => {
+    expect(getShownPages([0, 1, 2, 3], 1, 3)).toEqual([0, 1, 2]);
+    expect(getShownPages([0, 1, 2, 3], 3, 3)).toEqual([1, 2, 3]);
+    expect(getShownPages([0, 1, 2, 3], 3, 4)).toEqual([0, 1, 2, 3]);
+    expect(getShownPages([0, 1, 2, 3], 0, 4)).toEqual([0, 1, 2, 3]);
+    expect(getShownPages([0, 1, 2], 0, 0)).toEqual([]);
+    expect(getShownPages([], 5, 2)).toEqual([]);
+    expect(getShownPages([0, 1, 2], 3, 1)).toEqual([2]);
+    expect(getShownPages([0, 1, 2], 3, 0)).toEqual([]);
+  });
+
+  test('getLeftItemNumber', () => {
+    expect(getLeftItemNumber(5, 1, 2)).toBe(3);
+    expect(getLeftItemNumber(5, 5, 2)).toBe(9);
+    expect(getLeftItemNumber(3, 2, 3)).toBe(7);
+    expect(getLeftItemNumber(0, 2, 3)).toBe(0);
+  });
+
+  test('getRightItemNumber', () => {
+    expect(getRightItemNumber(1, 3, 3)).toBe(6);
+    expect(getRightItemNumber(1, 3, 2)).toBe(5);
+    expect(getRightItemNumber(0, 3, 1)).toBe(1);
+    expect(getRightItemNumber(1, 3, 0)).toBe(3);
+    expect(getRightItemNumber(2, 3, 0)).toBe(6);
+    expect(getRightItemNumber(3, 4, 0)).toBe(12);
+  });
+});

--- a/src/components/Pagination/Pagination.utils.ts
+++ b/src/components/Pagination/Pagination.utils.ts
@@ -1,0 +1,28 @@
+export const getShownPages = (pageArray: number[], activePageIndex: number, pagesPerView: number) => {
+  const pageCount = pageArray.length;
+  const maxVisiblePages = Math.min(pagesPerView, pageCount);
+  const pagesBehind = pagesPerView - (pagesPerView - Math.ceil(pagesPerView / 2)) - 1;
+  let firstPageIndex = Math.max(activePageIndex - pagesBehind, 0);
+  let lastPageIndex = firstPageIndex + maxVisiblePages;
+
+  // If we can't keep the selected page in the center anymore, it should just move rightwards
+  if (lastPageIndex >= pageCount + 1 && lastPageIndex - maxVisiblePages > 0) {
+    lastPageIndex = pageCount;
+    firstPageIndex = lastPageIndex - maxVisiblePages;
+  }
+
+  return pageArray.slice(firstPageIndex, lastPageIndex);
+};
+
+export const getLeftItemNumber = (pageCount: number, activePageIndex: number, pageSize: number) => {
+  let index = activePageIndex;
+
+  if (activePageIndex >= pageCount) {
+    index = pageCount - 1;
+  }
+
+  return pageCount > 0 ? index * pageSize + 1 : 0;
+};
+
+export const getRightItemNumber = (activePageIndex: number, pageSize: number, nrRowsOnCurrentPage: number) =>
+  activePageIndex * pageSize + nrRowsOnCurrentPage;

--- a/src/components/Pagination/index.ts
+++ b/src/components/Pagination/index.ts
@@ -1,0 +1,2 @@
+export * from './Pagination';
+export * from './Pagination.hooks';


### PR DESCRIPTION
In order to use Pagination from Integrated Alerting in QAN, Pagination was moved to core-ui in order to replace Pagination from ant-design in QAN in the future and remove unnecessary dependency in grafana-dashboard
https://jira.percona.com/browse/PMM-9481