### PR TITLE
PMM-10340-Simpler-K8s-registration: adding type to onChange event

### DIFF
--- a/src/shared/types/ReactFinalForm.ts
+++ b/src/shared/types/ReactFinalForm.ts
@@ -1,4 +1,4 @@
-import { InputHTMLAttributes, TextareaHTMLAttributes } from 'react';
+import { ChangeEvent, InputHTMLAttributes, TextareaHTMLAttributes } from 'react';
 
 type HtmlInputAttrs<T, IA = InputHTMLAttributes<T>> = {
   [P in keyof IA]?: IA[P];
@@ -13,4 +13,6 @@ export interface FieldInputAttrs extends Omit<HtmlInputAttrs<HTMLInputElement>, 
   multiple?: boolean;
 }
 
-export interface FieldTextareaAttrs extends Omit<HtmlTextareaAttrs<HTMLTextAreaElement>, 'name'> {}
+export interface FieldTextareaAttrs extends Omit<HtmlTextareaAttrs<HTMLTextAreaElement>, 'name'> {
+  onChange?: (event: ChangeEvent<HTMLTextAreaElement>) => void;
+}


### PR DESCRIPTION
fix of types for  https://github.com/percona-platform/grafana/pull/465

at the moment, using textareaInputField in other places does not allow to do the following:
```
inputProps={{
onChange: (event) => void
}}
```

typescript swears that the default onChange is described as `onChange: ()=> void`