### PR TITLE
PMM-10683-DBaaS-manage-versions-checkbox-broken: fixed name attr

### DIFF
--- a/src/components/Checkbox/Checkbox.tsx
+++ b/src/components/Checkbox/Checkbox.tsx
@@ -34,6 +34,7 @@ export const BaseCheckbox: FC<BaseCheckboxProps> = ({
       <label className={styles.wrapper} htmlFor={inputId}>
         <input
           id={inputId}
+          name={name}
           type="checkbox"
           {...props}
           data-testid={`${name}-checkbox-input`}


### PR DESCRIPTION
https://jira.percona.com/browse/PMM-10683
In Dbaas we had function checked name of checkboxes. Looks like we deleted name attribute from core-ui  or forgot it during refactoring checkbox component and this broke our checkboxes in dbaas. 

![image](https://user-images.githubusercontent.com/90199600/198034309-b6cab0b5-6b5c-4ec9-8dd5-52689334f68a.png)
