### PR TITLE
PMM-10732 Add option to select only one page

### DIFF
--- a/src/components/Table/Table.test.tsx
+++ b/src/components/Table/Table.test.tsx
@@ -19,6 +19,11 @@ const data = [
   },
 ];
 
+const createData = (length: number) =>
+  new Array(length).fill(null).map((_, idx) => ({
+    value: `test value ${idx + 1}`,
+  }));
+
 const onPaginationChanged = jest.fn();
 
 describe('Table', () => {
@@ -188,6 +193,7 @@ describe('Table', () => {
   });
 
   it('should allow selection of all rows', async () => {
+    const tableData = createData(20);
     let selectedValues: any[] = [];
 
     const onSelectionChanged = (rows: Row<any>[]) => {
@@ -196,10 +202,11 @@ describe('Table', () => {
 
     render(
       <Table
-        totalItems={data.length}
-        data={data}
+        totalItems={tableData.length}
+        data={tableData}
         columns={columns}
         rowSelection
+        showPagination
         onRowSelection={onSelectionChanged}
         onPaginationChanged={onPaginationChanged}
         emptyMessage="empty"
@@ -211,7 +218,38 @@ describe('Table', () => {
 
     fireEvent.click(selectAllCheckbox);
 
-    expect(selectedValues.length).toBe(2);
-    expect(selectedValues).toStrictEqual(data);
+    expect(selectedValues.length).toBe(20);
+    expect(selectedValues).toStrictEqual(tableData);
+  });
+
+  it('should select items only in current page when mode set to "page"', async () => {
+    const tableData = createData(20);
+    let selectedValues: any[] = [];
+
+    const onSelectionChanged = (rows: Row<any>[]) => {
+      selectedValues = rows.map((r) => r.values);
+    };
+
+    render(
+      <Table
+        totalItems={tableData.length}
+        data={tableData}
+        columns={columns}
+        rowSelection
+        showPagination
+        onRowSelection={onSelectionChanged}
+        onPaginationChanged={onPaginationChanged}
+        emptyMessage="empty"
+        allRowsSelectionMode="page"
+        pageSize={10}
+      />,
+    );
+
+    const selectAllCheckbox = await screen.findByTestId('table-select-all-checkbox-input');
+
+    fireEvent.click(selectAllCheckbox);
+
+    expect(selectedValues.length).toBe(10);
+    expect(selectedValues).toStrictEqual(tableData.slice(0, 10));
   });
 });

--- a/src/components/Table/Table.tsx
+++ b/src/components/Table/Table.tsx
@@ -47,6 +47,7 @@ export const Table: FC<TableProps> = ({
   autoResetPage = true,
   renderExpandedRow = () => <></>,
   onRowSelection,
+  allRowsSelectionMode = 'all',
   getHeaderProps = defaultPropGetter,
   getRowProps = defaultPropGetter,
   getColumnProps = defaultPropGetter,
@@ -86,9 +87,17 @@ export const Table: FC<TableProps> = ({
         {
           id: 'selection',
           width: '50px',
-          Header: ({ getToggleAllRowsSelectedProps }: UseRowSelectInstanceProps<any>) => (
+          Header: ({
+            getToggleAllRowsSelectedProps,
+            getToggleAllPageRowsSelectedProps,
+          }: UseRowSelectInstanceProps<any>) => (
             <div data-testid="select-all">
-              <TableCheckbox id="all" {...getToggleAllRowsSelectedProps()} />
+              <TableCheckbox
+                id="all"
+                {...(allRowsSelectionMode === 'all' || !showPagination
+                  ? getToggleAllRowsSelectedProps()
+                  : getToggleAllPageRowsSelectedProps())}
+              />
             </div>
           ),
           Cell: ({ row }: { row: UseRowSelectRowProps<any> & Row<any> }) => (

--- a/src/components/Table/Table.types.ts
+++ b/src/components/Table/Table.types.ts
@@ -30,6 +30,7 @@ export interface TableProps {
   autoResetPage?: boolean;
   autoResetExpanded?: boolean;
   rowSelection?: boolean;
+  allRowsSelectionMode?: 'all' | 'page';
   onRowSelection?: (rows: Row[]) => void;
   onPaginationChanged?: (pageSize: number, pageIndex: number) => void;
   children?: (rows: Row[], table: TableInstance) => React.ReactNode;


### PR DESCRIPTION
Adds option to only select rows on the current page in a table.

Needed as part of PMM-10732 on the inventory page in pmm.