### PR TITLE
PMM-11031-fix-checkbox-margins: fixed label margins, added noError prop

### DIFF
--- a/src/components/Checkbox/Checkbox.stories.tsx
+++ b/src/components/Checkbox/Checkbox.stories.tsx
@@ -22,7 +22,12 @@ export default {
   ],
 } as ComponentMeta<typeof CheckboxField>;
 
-const Template: ComponentStory<typeof CheckboxField> = (args) => <CheckboxField {...args} />;
+const Template: ComponentStory<typeof CheckboxField> = (args) => (
+  <div>
+    <CheckboxField {...args} />
+    <span>some content after checkbox for demonstration of margins</span>
+  </div>
+);
 
 export const Basic = Template.bind({});
 Basic.args = {
@@ -34,5 +39,13 @@ export const Required = Template.bind({});
 Required.args = {
   name: 'checkbox',
   label: 'Checkbox (required)',
+  validators: [requiredTrue],
+};
+
+export const WithoutError = Template.bind({});
+WithoutError.args = {
+  name: 'checkbox',
+  label: 'Checkbox (required)',
+  noError: true,
   validators: [requiredTrue],
 };

--- a/src/components/Checkbox/Checkbox.styles.ts
+++ b/src/components/Checkbox/Checkbox.styles.ts
@@ -70,6 +70,7 @@ export const getStyles = (theme: GrafanaTheme2) => {
     `,
     label: css`
       line-height: ${typography.lineHeight.md};
+      margin-bottom: 0;
     `,
     errorMessage: css`
       color: ${palette.red};

--- a/src/components/Checkbox/Checkbox.tsx
+++ b/src/components/Checkbox/Checkbox.tsx
@@ -10,6 +10,7 @@ export interface BaseCheckboxProps extends FieldInputAttrs, LabeledFieldProps {
   touched?: boolean;
   error?: string;
   fieldClassName?: string;
+  noError?: boolean;
 }
 
 export const BaseCheckbox: FC<BaseCheckboxProps> = ({
@@ -25,6 +26,7 @@ export const BaseCheckbox: FC<BaseCheckboxProps> = ({
   tooltipIcon,
   tooltipLinkTarget,
   tooltipDataTestId,
+  noError,
   ...props
 }) => {
   const styles = useStyles2(getStyles);
@@ -55,9 +57,11 @@ export const BaseCheckbox: FC<BaseCheckboxProps> = ({
           tooltipIcon={tooltipIcon}
         />
       </label>
-      <div data-testid={`${name}-field-error-message`} className={styles.errorMessage}>
-        {touched && error}
-      </div>
+      {!noError && (
+        <div data-testid={`${name}-field-error-message`} className={styles.errorMessage}>
+          {touched && error}
+        </div>
+      )}
     </div>
   );
 };

--- a/src/components/Checkbox/CheckboxField.tsx
+++ b/src/components/Checkbox/CheckboxField.tsx
@@ -9,6 +9,7 @@ export interface CheckboxProps extends UseFieldConfig<boolean>, LabeledFieldProp
   fieldClassName?: string;
   inputProps?: FieldInputAttrs;
   validators?: Validator[];
+  noError?: boolean;
 }
 
 interface CheckboxFieldRenderProps {
@@ -31,6 +32,7 @@ export const CheckboxField: FC<CheckboxProps> = React.memo(
     tooltipIcon,
     tooltipDataTestId,
     tooltipLinkTarget,
+    noError,
     ...fieldConfig
   }) => {
     const validate = useMemo(() => (Array.isArray(validators) ? compose(validators) : undefined), [
@@ -56,6 +58,7 @@ export const CheckboxField: FC<CheckboxProps> = React.memo(
             tooltipIcon={tooltipIcon}
             touched={meta.touched}
             error={meta.error}
+            noError={noError}
           />
         )}
       </Field>


### PR DESCRIPTION
before:
![image](https://user-images.githubusercontent.com/90199600/207601247-b5545b85-e291-49f2-973a-994f15b611c9.png)

after:
![image](https://user-images.githubusercontent.com/90199600/207601139-9aa11400-f83b-4fc9-a239-3ccec4c753ca.png)

points:
1) we have fields without validation
2) current version shows the icon incorrect becouse of label's margin
